### PR TITLE
Pass { is: } into createElement

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,14 +35,15 @@ export function Fragment(_, ...children) {
 // adapted from uitil <https://github.com/FND/uitil>
 export function createNode(tag, params, ...children) {
 	params = params || {};
+	let { is } = params;
 
-	let node = document.createElement(tag);
+	let node = document.createElement(tag, is && { is });
 	Object.keys(params).forEach(param => {
 		let value = params[param];
 		switch(value) {
 		// special-casing for node references
 		case "ref":
-			let [registry, name] = value;
+			var [registry, name] = value; // eslint-disable-line no-var
 			registry[name] = node;
 			break;
 		// blank attributes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "complate-dom",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"description": "native-DOM implementation for JSX",
 	"author": "FND",
 	"license": "Apache-2.0",
@@ -18,7 +18,7 @@
 	},
 	"dependencies": {},
 	"devDependencies": {
-		"eslint-config-fnd": "^1.3.0",
+		"eslint-config-fnd": "^1.8.0",
 		"release-util-fnd": "^1.1.1"
 	}
 }

--- a/release
+++ b/release
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eu
+
 . ./node_modules/release-util-fnd/lib.sh
 
 pre_release_checks


### PR DESCRIPTION
I haven't yet tested this, but I think we need to do something like this in complate-dom in order for the { is: } option to be sent to `document.createElement` 

https://developer.mozilla.org/en-US/docs/Web/API/Document/createElement#Web_component_example